### PR TITLE
fix: identify reported arch 'amd64' as amd64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -42,7 +42,7 @@ detect_system() {
 
 detect_architecture() {
   case $(uname -m) in
-    x86_64) echo "amd64" ;;
+    amd64 | x86_64) echo "amd64" ;;
     ppc64le) echo "ppc64le" ;;
     aarch64 | aarch64_be | armv8b | armv8l | arm64) echo "arm64" ;;
     *) fail "Architecture not supported" ;;


### PR DESCRIPTION
`uname -m` reports x86_64 as `amd64`. Tested in FreeBSD 13.1-RELEASE.

Signed-off-by: Kyle Aleshire <kjaleshire@gmail.com>