### PR TITLE
fix: Assume glibc when `ldd` command not present

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -51,7 +51,7 @@ detect_architecture() {
 }
 
 detect_variant() {
-  case "$(ldd /bin/sh)" in
+  case "$(command -v ldd >/dev/null && ldd /bin/sh)" in
     *musl*) echo '-musl';;
     *) echo '';
   esac


### PR DESCRIPTION
Before:

```
$ asdf install chezmoi latest
/Users/samumbach/.asdf/plugins/chezmoi/lib/utils.bash: line 54: ldd: command not found
* Downloading chezmoi release 2.42.0...
chezmoi 2.42.0 installation was successful!
```

After:

```
$ asdf install chezmoi latest
* Downloading chezmoi release 2.42.0...
chezmoi 2.42.0 installation was successful!
```
